### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/okan/homeros/security/code-scanning/1](https://github.com/okan/homeros/security/code-scanning/1)

To fix this issue, you need to add an explicit `permissions` block to the workflow that restricts the permissions granted to the GITHUB_TOKEN used by GitHub Actions. The minimal starting point and best practice is to specify `permissions: contents: read` at either the workflow root or at the job level (for each job that only requires read access to repository files). As there is only one job and no evidence that anything in the workflow needs elevated permissions, adding this at the workflow root is the best solution. This change should be made near the top of the workflow file (`.github/workflows/ci.yml`), right after the `name` block and before the workflow triggers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
